### PR TITLE
Enchance config.yaml (More detailed diversion and WeChat FCM support)

### DIFF
--- a/box_bll/clash/enhanced_config.yaml
+++ b/box_bll/clash/enhanced_config.yaml
@@ -1,0 +1,318 @@
+mixed-port: 7890
+redir-port: 7891
+tproxy-port: 1536
+allow-lan: true
+mode: Rule
+geodata-mode: true
+geodata-loader: standard
+unified-delay: true
+log-level: silent
+ipv6: true
+external-controller: 0.0.0.0:9090
+
+#面板默认Meta 可选Yacd 清除浏览器缓存即可重新加载
+external-ui: ./dashboard/Meta #Yacd
+secret: ""
+
+tcp-concurrent: true
+enable-process: true
+find-process-mode: strict
+global-client-fingerprint: chrome
+
+#####################
+#修改配置文件时，建议先停止模块服务，再进行保存.
+#####################
+
+geo-auto-update: true
+geo-update-interval: 24
+geox-url:
+  geoip: "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat"
+  geosite: "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat"
+  mmdb: "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/country.mmdb"
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  override-destination: true
+  sniff:
+    HTTP:
+      ports: [80, 8080-8880]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+    QUIC:
+      ports: [443, 8443]
+  force-domain:
+    - "+.v2ex.com"
+  skip-domain:
+    - "Mijia Cloud"
+
+tun:
+  enable: false
+  device: tun0
+  stack: system
+  dns-hijack:
+    - "any:53"
+    - "tcp://any:53"
+  auto-route: true
+  auto-detect-interface: true
+  
+dns:
+  enable: true
+  prefer-h3: true
+  listen: 0.0.0.0:1053
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.0/15
+  fake-ip-filter:
+    - "*"
+    - "+.lan"
+    - "connect.rom.miui.com"
+    - "localhost.ptlogin2.qq.com"
+ 
+  nameserver:
+    - "https://doh.pub/dns-query"
+    - "https://dns.alidns.com/dns-query"
+
+p: &p
+  {type: http, url: "Your Clash Subscribe Link", interval: 21600, health-check: {enable: true, url: https://www.gstatic.com/generate_204, interval: 300}}
+
+proxy-providers:
+  HongKong:
+    <<: *p
+    filter: "^(?=.*(港|HK|hk|Hong Kong|HongKong|hongkong))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/HongKong.yaml
+  Japan:
+    <<: *p
+    filter: "^(?=.*(日本|川日|东京|大阪|泉日|埼玉|沪日|深日|[^-]日|JP|Japan))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/Japan.yaml
+  America:
+    <<: *p
+    filter: "^(?=.*(美|波特兰|达拉斯|俄勒冈|凤凰城|费利蒙|硅谷|拉斯维加斯|洛杉矶|圣何塞|圣克拉拉|西雅图|芝加哥|US|United States))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/America.yaml
+  Taiwan:
+    <<: *p
+    filter: "^(?=.*(台|新北|彰化|TW|Taiwan))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/Taiwan.yaml
+  Singapore:
+    <<: *p
+    filter: "^(?=.*(新加坡|坡|狮城|SG|Singapore))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/Singapore.yaml
+  Resilience:
+    <<: *p
+    filter: "^(?=.*(灾))(?!.*(网易|Netease)).*"
+    path: ./proxy_providers/Resilience.yaml
+  All: 
+    <<: *p
+    filter: "^(?!.*(网易|订阅|群|账户|流量|有效期|时间|官网)).*$"
+    path: ./proxy_providers/All.yaml
+  Neteasemusic: 
+    <<: *p
+    filter: "(Netease)"
+    path: ./proxy_providers/Neteasemusic.yaml
+
+proxy-groups:
+  - {name: 🚀 节点选择, type: select, proxies: [♻️ 自动选择, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 🚀 手动切换, type: select, use: [All]}
+  - {name: ♻️ 自动选择, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [All]}
+  - {name: 📲 Telegram, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 💬 OpenAI, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 📹 YouTube, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 🎥 Netflix, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 📺 巴哈姆特, type: select, proxies: [🇨🇳 台湾节点, 🚀 节点选择, 🚀 手动切换, DIRECT]}
+  - {name: 📺 哔哩哔哩, type: select, proxies: [🎯 全球直连, 🇨🇳 台湾节点, 🇭🇰 香港节点]}
+  - {name: 🌍 国外媒体, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 🌏 国内媒体, type: select, proxies: [DIRECT, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 📢 谷歌FCM, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: Ⓜ️ 微软Bing, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: Ⓜ️ 微软云盘, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: Ⓜ️ 微软服务, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 🍎 苹果服务, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 🎮 游戏平台, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 🎶 网易音乐, type: select, proxies: [DIRECT], use: [Neteasemusic]}
+  - {name: 🎯 全球直连, type: select, proxies: [DIRECT, 🚀 节点选择, ♻️ 自动选择]}
+  - {name: 🛑 广告拦截, type: select, proxies: [REJECT, DIRECT]}
+  - {name: 🍃 应用净化, type: select, proxies: [REJECT, DIRECT]}
+  - {name: 🐟 漏网之鱼, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, DIRECT, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换]}
+  - {name: 🇭🇰 香港节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [HongKong]}
+  - {name: 🇯🇵 日本节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [Japan]}
+  - {name: 🇺🇲 美国节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 700, use: [America]}
+  - {name: 🇨🇳 台湾节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [Taiwan]}
+  - {name: 🇸🇬 狮城节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [Singapore]}
+
+RuleDefault: &RuleDefault
+  {type: http, behavior: classical, format: text, interval: 86400}
+
+rule-providers:
+  LocalAreaNetwork:
+    <<: *RuleDefault
+    path: ./rule/LocalAreaNetwork.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/LocalAreaNetwork.list"
+  UnBan:
+    <<: *RuleDefault
+    path: ./rule/UnBan.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/UnBan.list"
+  BanAD:
+    <<: *RuleDefault
+    path: ./rule/BanAD.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list"
+  BanProgramAD:
+    <<: *RuleDefault
+    path: ./rule/BanProgramAD.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanProgramAD.list"
+  GoogleFCM:
+    <<: *RuleDefault
+    path: ./rule/GoogleFCM.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/GoogleFCM.list"
+  WechatFCM:
+    <<: *RuleDefault
+    path: ./rule/WechatFCM.list
+    url: "https://raw.githubusercontent.com/Snowflake-Pink/Files4Converter/master/Clash/WechatFCM.list"
+  GoogleCN:
+    <<: *RuleDefault
+    path: ./rule/GoogleCN.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/GoogleCN.list"
+  SteamCN:
+    <<: *RuleDefault
+    path: ./rule/SteamCN.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/SteamCN.list"
+  Bing:
+    <<: *RuleDefault
+    path: ./rule/Bing.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Bing.list"
+  OneDrive:
+    <<: *RuleDefault
+    path: ./rule/OneDrive.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/OneDrive.list"
+  Microsoft:
+    <<: *RuleDefault
+    path: ./rule/Microsoft.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Microsoft.list"
+  Apple:
+    <<: *RuleDefault
+    path: ./rule/Apple.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Apple.list"
+  Telegram:
+    <<: *RuleDefault
+    path: ./rule/Telegram.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Telegram.list"
+  OpenAi:
+    <<: *RuleDefault
+    path: ./rule/OpenAi.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list"
+  NetEaseMusic:
+    <<: *RuleDefault
+    path: ./rule/NetEaseMusic.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/NetEaseMusic.list"
+  Epic:
+    <<: *RuleDefault
+    path: ./rule/Epic.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Epic.list"
+  Origin:
+    <<: *RuleDefault
+    path: ./rule/Origin.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Origin.list"
+  Sony:
+    <<: *RuleDefault
+    path: ./rule/Sony.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Sony.list"
+  Steam:
+    <<: *RuleDefault
+    path: ./rule/Steam.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Steam.list"
+  Nintendo:
+    <<: *RuleDefault
+    path: ./rule/Nintendo.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Nintendo.list"
+  Youtube:
+    <<: *RuleDefault
+    path: ./rule/Youtube.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/YouTube.list"
+  Netflix:
+    <<: *RuleDefault
+    path: ./rule/Netflix.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Netflix.list"
+  Bahamut:
+    <<: *RuleDefault
+    path: ./rule/Bahamut.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Bahamut.list"
+  BilibiliHMT:
+    <<: *RuleDefault
+    path: ./rule/BilibiliHMT.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/BilibiliHMT.list"
+  Bilibili:
+    <<: *RuleDefault
+    path: ./rule/Bilibili.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Bilibili.list"
+  ChinaMedia:
+    <<: *RuleDefault
+    path: ./rule/ChinaMedia.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaMedia.list"
+  ProxyMedia:
+    <<: *RuleDefault
+    path: ./rule/ProxyMedia.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyMedia.list"
+  ProxyGFWlist:
+    <<: *RuleDefault
+    path: ./rule/ProxyGFWlist.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyGFWlist.list"
+  ChinaDomain:
+    <<: *RuleDefault
+    path: ./rule/ChinaDomain.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaDomain.list"
+  ChinaCompanyIp:
+    <<: *RuleDefault
+    path: ./rule/ChinaCompanyIp.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaCompanyIp.list"
+  Download:
+    <<: *RuleDefault
+    path: ./rule/Download.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Download.list"
+
+rules:
+  - AND,((PROCESS-NAME,mihomo),(NOT,((IN-TYPE,inner)))),REJECT
+  - AND,((PROCESS-NAME,clash),(NOT,((IN-TYPE,inner)))),REJECT
+  - PROCESS-NAME,com.zhiliaoapp.musically,🌍 国外媒体
+  - PROCESS-NAME,com.ss.android.ugc.aweme,🎯 全球直连
+  - PROCESS-NAME,com.netease.cloudmusic,🎶 网易音乐
+  - RULE-SET,LocalAreaNetwork,🎯 全球直连
+  - RULE-SET,UnBan,🎯 全球直连
+  - RULE-SET,BanAD,🛑 广告拦截
+  - RULE-SET,BanProgramAD,🍃 应用净化
+  - RULE-SET,GoogleFCM,📢 谷歌FCM
+  - RULE-SET,WechatFCM,📢 谷歌FCM
+  - RULE-SET,GoogleCN,🎯 全球直连
+  - RULE-SET,SteamCN,🎯 全球直连
+  - RULE-SET,Bing,Ⓜ️ 微软Bing
+  - RULE-SET,OneDrive,Ⓜ️ 微软云盘
+  - RULE-SET,Microsoft,Ⓜ️ 微软服务
+  - RULE-SET,Apple,🍎 苹果服务
+  - RULE-SET,Telegram,📲 Telegram
+  - RULE-SET,OpenAi,💬 OpenAI
+  - RULE-SET,NetEaseMusic,🎶 网易音乐
+  - RULE-SET,Epic,🎮 游戏平台
+  - RULE-SET,Origin,🎮 游戏平台
+  - RULE-SET,Sony,🎮 游戏平台
+  - RULE-SET,Steam,🎮 游戏平台
+  - RULE-SET,Nintendo,🎮 游戏平台
+  - RULE-SET,Youtube,📹 YouTube
+  - RULE-SET,Netflix,🎥 Netflix
+  - RULE-SET,Bahamut,📺 巴哈姆特
+  - RULE-SET,BilibiliHMT,📺 哔哩哔哩
+  - RULE-SET,Bilibili,📺 哔哩哔哩
+  - RULE-SET,ChinaMedia,🌏 国内媒体
+  - RULE-SET,ProxyMedia,🌍 国外媒体
+  - RULE-SET,ProxyGFWlist,🚀 节点选择
+  - RULE-SET,ChinaDomain,🎯 全球直连
+  - RULE-SET,ChinaCompanyIp,🎯 全球直连
+  - RULE-SET,Download,🎯 全球直连
+  - GEOSITE,category-ads-all,🛑 广告拦截
+  - GEOSITE,CN,🎯 全球直连
+  - GEOIP,private,🎯 全球直连,no-resolve
+  - GEOIP,CN,🎯 全球直连,no-resolve
+  - MATCH,🐟 漏网之鱼

--- a/box_bll/clash/enhanced_config.yaml.bak
+++ b/box_bll/clash/enhanced_config.yaml.bak
@@ -1,0 +1,318 @@
+mixed-port: 7890
+redir-port: 7891
+tproxy-port: 1536
+allow-lan: true
+mode: Rule
+geodata-mode: true
+geodata-loader: standard
+unified-delay: true
+log-level: silent
+ipv6: true
+external-controller: 0.0.0.0:9090
+
+#面板默认Meta 可选Yacd 清除浏览器缓存即可重新加载
+external-ui: ./dashboard/Meta #Yacd
+secret: ""
+
+tcp-concurrent: true
+enable-process: true
+find-process-mode: strict
+global-client-fingerprint: chrome
+
+#####################
+#修改配置文件时，建议先停止模块服务，再进行保存.
+#####################
+
+geo-auto-update: true
+geo-update-interval: 24
+geox-url:
+  geoip: "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat"
+  geosite: "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat"
+  mmdb: "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/country.mmdb"
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  override-destination: true
+  sniff:
+    HTTP:
+      ports: [80, 8080-8880]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+    QUIC:
+      ports: [443, 8443]
+  force-domain:
+    - "+.v2ex.com"
+  skip-domain:
+    - "Mijia Cloud"
+
+tun:
+  enable: false
+  device: tun0
+  stack: system
+  dns-hijack:
+    - "any:53"
+    - "tcp://any:53"
+  auto-route: true
+  auto-detect-interface: true
+  
+dns:
+  enable: true
+  prefer-h3: true
+  listen: 0.0.0.0:1053
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.0/15
+  fake-ip-filter:
+    - "*"
+    - "+.lan"
+    - "connect.rom.miui.com"
+    - "localhost.ptlogin2.qq.com"
+ 
+  nameserver:
+    - "https://doh.pub/dns-query"
+    - "https://dns.alidns.com/dns-query"
+
+p: &p
+  {type: http, url: "Your Clash Subscribe Link", interval: 21600, health-check: {enable: true, url: https://www.gstatic.com/generate_204, interval: 300}}
+
+proxy-providers:
+  HongKong:
+    <<: *p
+    filter: "^(?=.*(港|HK|hk|Hong Kong|HongKong|hongkong))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/HongKong.yaml
+  Japan:
+    <<: *p
+    filter: "^(?=.*(日本|川日|东京|大阪|泉日|埼玉|沪日|深日|[^-]日|JP|Japan))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/Japan.yaml
+  America:
+    <<: *p
+    filter: "^(?=.*(美|波特兰|达拉斯|俄勒冈|凤凰城|费利蒙|硅谷|拉斯维加斯|洛杉矶|圣何塞|圣克拉拉|西雅图|芝加哥|US|United States))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/America.yaml
+  Taiwan:
+    <<: *p
+    filter: "^(?=.*(台|新北|彰化|TW|Taiwan))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/Taiwan.yaml
+  Singapore:
+    <<: *p
+    filter: "^(?=.*(新加坡|坡|狮城|SG|Singapore))(?!.*(灾|网易|Netease)).*"
+    path: ./proxy_providers/Singapore.yaml
+  Resilience:
+    <<: *p
+    filter: "^(?=.*(灾))(?!.*(网易|Netease)).*"
+    path: ./proxy_providers/Resilience.yaml
+  All: 
+    <<: *p
+    filter: "^(?!.*(网易|订阅|群|账户|流量|有效期|时间|官网)).*$"
+    path: ./proxy_providers/All.yaml
+  Neteasemusic: 
+    <<: *p
+    filter: "(Netease)"
+    path: ./proxy_providers/Neteasemusic.yaml
+
+proxy-groups:
+  - {name: 🚀 节点选择, type: select, proxies: [♻️ 自动选择, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 🚀 手动切换, type: select, use: [All]}
+  - {name: ♻️ 自动选择, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [All]}
+  - {name: 📲 Telegram, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 💬 OpenAI, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 📹 YouTube, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 🎥 Netflix, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇸🇬 狮城节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 📺 巴哈姆特, type: select, proxies: [🇨🇳 台湾节点, 🚀 节点选择, 🚀 手动切换, DIRECT]}
+  - {name: 📺 哔哩哔哩, type: select, proxies: [🎯 全球直连, 🇨🇳 台湾节点, 🇭🇰 香港节点]}
+  - {name: 🌍 国外媒体, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换, DIRECT]}
+  - {name: 🌏 国内媒体, type: select, proxies: [DIRECT, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 📢 谷歌FCM, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: Ⓜ️ 微软Bing, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: Ⓜ️ 微软云盘, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: Ⓜ️ 微软服务, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 🍎 苹果服务, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 🎮 游戏平台, type: select, proxies: [DIRECT, 🚀 节点选择, 🇺🇲 美国节点, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🚀 手动切换]}
+  - {name: 🎶 网易音乐, type: select, proxies: [DIRECT], use: [Neteasemusic]}
+  - {name: 🎯 全球直连, type: select, proxies: [DIRECT, 🚀 节点选择, ♻️ 自动选择]}
+  - {name: 🛑 广告拦截, type: select, proxies: [REJECT, DIRECT]}
+  - {name: 🍃 应用净化, type: select, proxies: [REJECT, DIRECT]}
+  - {name: 🐟 漏网之鱼, type: select, proxies: [🚀 节点选择, ♻️ 自动选择, DIRECT, 🇭🇰 香港节点, 🇨🇳 台湾节点, 🇸🇬 狮城节点, 🇯🇵 日本节点, 🇺🇲 美国节点, 🚀 手动切换]}
+  - {name: 🇭🇰 香港节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [HongKong]}
+  - {name: 🇯🇵 日本节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [Japan]}
+  - {name: 🇺🇲 美国节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 700, use: [America]}
+  - {name: 🇨🇳 台湾节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [Taiwan]}
+  - {name: 🇸🇬 狮城节点, type: url-test, url: http://www.gstatic.com/generate_204, interval: 300, tolerance: 500, use: [Singapore]}
+
+RuleDefault: &RuleDefault
+  {type: http, behavior: classical, format: text, interval: 86400}
+
+rule-providers:
+  LocalAreaNetwork:
+    <<: *RuleDefault
+    path: ./rule/LocalAreaNetwork.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/LocalAreaNetwork.list"
+  UnBan:
+    <<: *RuleDefault
+    path: ./rule/UnBan.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/UnBan.list"
+  BanAD:
+    <<: *RuleDefault
+    path: ./rule/BanAD.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list"
+  BanProgramAD:
+    <<: *RuleDefault
+    path: ./rule/BanProgramAD.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanProgramAD.list"
+  GoogleFCM:
+    <<: *RuleDefault
+    path: ./rule/GoogleFCM.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/GoogleFCM.list"
+  WechatFCM:
+    <<: *RuleDefault
+    path: ./rule/WechatFCM.list
+    url: "https://raw.githubusercontent.com/Snowflake-Pink/Files4Converter/master/Clash/WechatFCM.list"
+  GoogleCN:
+    <<: *RuleDefault
+    path: ./rule/GoogleCN.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/GoogleCN.list"
+  SteamCN:
+    <<: *RuleDefault
+    path: ./rule/SteamCN.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/SteamCN.list"
+  Bing:
+    <<: *RuleDefault
+    path: ./rule/Bing.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Bing.list"
+  OneDrive:
+    <<: *RuleDefault
+    path: ./rule/OneDrive.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/OneDrive.list"
+  Microsoft:
+    <<: *RuleDefault
+    path: ./rule/Microsoft.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Microsoft.list"
+  Apple:
+    <<: *RuleDefault
+    path: ./rule/Apple.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Apple.list"
+  Telegram:
+    <<: *RuleDefault
+    path: ./rule/Telegram.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Telegram.list"
+  OpenAi:
+    <<: *RuleDefault
+    path: ./rule/OpenAi.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list"
+  NetEaseMusic:
+    <<: *RuleDefault
+    path: ./rule/NetEaseMusic.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/NetEaseMusic.list"
+  Epic:
+    <<: *RuleDefault
+    path: ./rule/Epic.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Epic.list"
+  Origin:
+    <<: *RuleDefault
+    path: ./rule/Origin.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Origin.list"
+  Sony:
+    <<: *RuleDefault
+    path: ./rule/Sony.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Sony.list"
+  Steam:
+    <<: *RuleDefault
+    path: ./rule/Steam.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Steam.list"
+  Nintendo:
+    <<: *RuleDefault
+    path: ./rule/Nintendo.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Nintendo.list"
+  Youtube:
+    <<: *RuleDefault
+    path: ./rule/Youtube.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/YouTube.list"
+  Netflix:
+    <<: *RuleDefault
+    path: ./rule/Netflix.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Netflix.list"
+  Bahamut:
+    <<: *RuleDefault
+    path: ./rule/Bahamut.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Bahamut.list"
+  BilibiliHMT:
+    <<: *RuleDefault
+    path: ./rule/BilibiliHMT.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/BilibiliHMT.list"
+  Bilibili:
+    <<: *RuleDefault
+    path: ./rule/Bilibili.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/Bilibili.list"
+  ChinaMedia:
+    <<: *RuleDefault
+    path: ./rule/ChinaMedia.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaMedia.list"
+  ProxyMedia:
+    <<: *RuleDefault
+    path: ./rule/ProxyMedia.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyMedia.list"
+  ProxyGFWlist:
+    <<: *RuleDefault
+    path: ./rule/ProxyGFWlist.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyGFWlist.list"
+  ChinaDomain:
+    <<: *RuleDefault
+    path: ./rule/ChinaDomain.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaDomain.list"
+  ChinaCompanyIp:
+    <<: *RuleDefault
+    path: ./rule/ChinaCompanyIp.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaCompanyIp.list"
+  Download:
+    <<: *RuleDefault
+    path: ./rule/Download.list
+    url: "https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Download.list"
+
+rules:
+  - AND,((PROCESS-NAME,mihomo),(NOT,((IN-TYPE,inner)))),REJECT
+  - AND,((PROCESS-NAME,clash),(NOT,((IN-TYPE,inner)))),REJECT
+  - PROCESS-NAME,com.zhiliaoapp.musically,🌍 国外媒体
+  - PROCESS-NAME,com.ss.android.ugc.aweme,🎯 全球直连
+  - PROCESS-NAME,com.netease.cloudmusic,🎶 网易音乐
+  - RULE-SET,LocalAreaNetwork,🎯 全球直连
+  - RULE-SET,UnBan,🎯 全球直连
+  - RULE-SET,BanAD,🛑 广告拦截
+  - RULE-SET,BanProgramAD,🍃 应用净化
+  - RULE-SET,GoogleFCM,📢 谷歌FCM
+  - RULE-SET,WechatFCM,📢 谷歌FCM
+  - RULE-SET,GoogleCN,🎯 全球直连
+  - RULE-SET,SteamCN,🎯 全球直连
+  - RULE-SET,Bing,Ⓜ️ 微软Bing
+  - RULE-SET,OneDrive,Ⓜ️ 微软云盘
+  - RULE-SET,Microsoft,Ⓜ️ 微软服务
+  - RULE-SET,Apple,🍎 苹果服务
+  - RULE-SET,Telegram,📲 Telegram
+  - RULE-SET,OpenAi,💬 OpenAI
+  - RULE-SET,NetEaseMusic,🎶 网易音乐
+  - RULE-SET,Epic,🎮 游戏平台
+  - RULE-SET,Origin,🎮 游戏平台
+  - RULE-SET,Sony,🎮 游戏平台
+  - RULE-SET,Steam,🎮 游戏平台
+  - RULE-SET,Nintendo,🎮 游戏平台
+  - RULE-SET,Youtube,📹 YouTube
+  - RULE-SET,Netflix,🎥 Netflix
+  - RULE-SET,Bahamut,📺 巴哈姆特
+  - RULE-SET,BilibiliHMT,📺 哔哩哔哩
+  - RULE-SET,Bilibili,📺 哔哩哔哩
+  - RULE-SET,ChinaMedia,🌏 国内媒体
+  - RULE-SET,ProxyMedia,🌍 国外媒体
+  - RULE-SET,ProxyGFWlist,🚀 节点选择
+  - RULE-SET,ChinaDomain,🎯 全球直连
+  - RULE-SET,ChinaCompanyIp,🎯 全球直连
+  - RULE-SET,Download,🎯 全球直连
+  - GEOSITE,category-ads-all,🛑 广告拦截
+  - GEOSITE,CN,🎯 全球直连
+  - GEOIP,private,🎯 全球直连,no-resolve
+  - GEOIP,CN,🎯 全球直连,no-resolve
+  - MATCH,🐟 漏网之鱼


### PR DESCRIPTION
If Wechat FCM support is not needed, it can be deleted by the line '  - RULE-SET,WechatFCM,📢 谷歌FCM'