### PR TITLE
fix ssid pharse error in hyperos 3

### DIFF
--- a/box_bll/scripts/ctr.utils
+++ b/box_bll/scripts/ctr.utils
@@ -1,17 +1,33 @@
 #!/system/bin/sh
 
 get_current_ssid() {
-    SSID=$(dumpsys wifi | grep 'mWifiInfo' | head -n 1 | cut -d '"' -f 2)
+    SSID_LINE=$(dumpsys wifi | grep 'mWifiInfo' | head -n 1)
+
+    if [ -n "$SSID_LINE" ]; then
+        SSID=$(echo "$SSID_LINE" | awk -F 'SSID: ' '{print $2}' | awk -F ',' '{print $1}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    else
+        SSID=""
+    fi
+
+    if [ -z "$SSID" ] || [ "$SSID" = "<unknown ssid>" ]; then
+        
+        COMPLETED_SSID=$(dumpsys wifi | grep 'COMPLETED' | head -n 1 | cut -d '"' -f 2)
+
+        if [ -n "$COMPLETED_SSID" ] && [ "$COMPLETED_SSID" != "<unknown ssid>" ]; then
+            SSID="$COMPLETED_SSID"
+        fi
+    fi
+
     if [ -z "$SSID" ] || [ "$SSID" = "<unknown ssid>" ]; then
         SSID=$(iwconfig wlan0 | grep 'ESSID' | awk -F ':' '{print $2}' | tr -d '"')
+
         if [ -z "$SSID" ] || [ "$SSID" = "off/any" ]; then
             echo "unknown"
-        else
-            echo "$SSID"
+            return
         fi
-    else
-        echo "$SSID"
     fi
+    
+    echo "$SSID"
 }
 is_wifi_connected() {
     wifi_enabled=$(dumpsys wifi | grep 'Wi-Fi is enabled')


### PR DESCRIPTION
In hyperos 3 the `dumpsys wifi | grep 'mWifiInfo' | head -n 1 | cut -d '"' -f 2` returns follwing SSID value:
`ssid:mWifiInfo SSID: <unknown ssid>, BSSID: <none>, MAC: 02:00:00:00:00:00, IP: null, Security type: -1, Supplicant state: DISCONNECTED, Wi-Fi standard: unknown, RSSI: -127, Link speed: -1Mbps, Tx Link speed: -1Mbps, Max Supported Tx Link speed: -1Mbps, Rx Link speed: -1Mbps, Max Supported Rx Link speed: -1Mbps, Frequency: -1MHz, Net ID: -1, Metered hint: false, score: 0, isUsable: true, CarrierMerged: false, SubscriptionId: -1, IsPrimary: 0, Trusted: false, Restricted: false, Ephemeral: false, OEM paid: false, OEM private: false, OSU AP: false, FQDN: <none>, Provider friendly name: <none>, Requesting package name: <none><none>MLO Information: , Is TID-To-Link negotiation supported by the AP: false, AP MLD Address: <none>, AP MLO Link Id: <none>, AP MLO Affiliated links: <none>, Vendor Data: <none>`

which is not null or `<unknown ssid>`, and it will be the wrong SSID passed to following script to do the whitelist/blacklist check.

This patch will fix this error.