### PR TITLE
Attempt to uninstall Surfing-related apps when uninstalling Surfing

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -52,8 +52,7 @@ uninstall_package() {
             sleep 1
         done
     fi
-    pm uninstall "$package_name"
-
+    pm uninstall "$package_name" || pm uninstall --user 0 "$package_name"
 }
 
 while [ "$(getprop vold.decrypt)" = "1" ]; do


### PR DESCRIPTION
Create a single-use script uninstall_Surfing.sh in the directory /data/adb/service.d/ to uninstall apps related to Surfing.
- For devices with a decrypted data partition, uninstall the apps directly after boot completed.
- For devices with an encrypted data partition, wait until the user unlocks the screen for the first time after boot completed, then uninstall the apps.
- Self-cleanup: Once all uninstall operations are complete, the script uninstall_Surfing.sh will delete itself.